### PR TITLE
Fix return type of build in helper

### DIFF
--- a/helper.d.ts
+++ b/helper.d.ts
@@ -1,10 +1,8 @@
 import fastify from 'fastify'
 
 declare module 'fastify-cli/helper.js' {
-    type fastifyFunctionReturnType = ReturnType<fastify>;
-
     module helper {
-        export function build(argv: Array<string>, config: Object): fastifyFunctionReturnType;
+        export function build(argv: Array<string>, config: Object): ReturnType<typeof fastify>;
     }
 
     export = helper;


### PR DESCRIPTION
The call to `typeof` was missing so `build` type was incorrect and returned any.